### PR TITLE
Fix frame deletion bug and refactor ffmpeg call

### DIFF
--- a/extract_distinct_frames/__main__.py
+++ b/extract_distinct_frames/__main__.py
@@ -10,11 +10,11 @@ from .download_video import download_video
 from .extract_image import extract_image
 
 logger = logging.getLogger()
-START_TIME = time.time()
 
 
 def main():
     args = parse_args()
+    start_time = time.time()
     # Downloading video
     if not args.file:
         if not args.url:
@@ -48,7 +48,7 @@ def main():
             score = compare_image(old, file)
             # Threshold = 2
             if score < 2:
-                Path.unlink(file)
+                file.unlink()
             else:
                 old = file
 
@@ -66,7 +66,7 @@ def main():
     with open(f"{filename}.pdf", "wb") as f:
         f.write(img2pdf.convert(images))
 
-    logger.info("Runtime : %.2f seconds" % (time.time() - START_TIME))
+    logger.info("Runtime : %.2f seconds", time.time() - start_time)
 
 
 def parse_args():
@@ -79,8 +79,9 @@ def parse_args():
         const=logging.DEBUG,
         default=logging.INFO,
     )
-    parser.add_argument("-f", "--file", help="Video file", type=str)
-    parser.add_argument("-u", "--url", help="URL of the video", type=str)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-f", "--file", help="Video file", type=str)
+    group.add_argument("-u", "--url", help="URL of the video", type=str)
     args = parser.parse_args()
     logging.basicConfig(level=args.loglevel)
     return args

--- a/extract_distinct_frames/extract_image.py
+++ b/extract_distinct_frames/extract_image.py
@@ -1,11 +1,22 @@
-import os
 import logging
+import subprocess
 
 logger = logging.getLogger(__name__)
 
 
 def extract_image(file, directory):
     logger.info("Extracting images from %s to %s", file, directory)
-    os.system(
-        f'ffmpeg -i "{file}" -vf fps=0.25 "{directory}/thumb%04d.jpg" -hide_banner >/dev/null 2>&1'
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-i",
+            str(file),
+            "-vf",
+            "fps=0.25",
+            f"{directory}/thumb%04d.jpg",
+            "-hide_banner",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
     )


### PR DESCRIPTION
## Summary
- fix incorrect call to `Path.unlink`
- use `subprocess.run` for ffmpeg invocation
- measure runtime in `main`
- require either `--file` or `--url`

## Testing
- `python -m py_compile extract_distinct_frames/*.py`
- `python -m extract_distinct_frames --help`

------
https://chatgpt.com/codex/tasks/task_e_68710ffdbec0832c930a3956c0ae26fe